### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,11 +171,11 @@ You can also give this repository a star to show more people and they can use th
 
 ## :star2: Star History
 
-<a href="https://star-history.com/#sanidhyy/space-portfolio&Timeline">
+<a href="https://star-history.dera.page/#sanidhyy/space-portfolio&type=Timeline">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=sanidhyy/space-portfolio&type=Timeline&theme=dark" />
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=sanidhyy/space-portfolio&type=Timeline" />
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=sanidhyy/space-portfolio&type=Timeline" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=sanidhyy/space-portfolio&type=Timeline&theme=dark" />
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=sanidhyy/space-portfolio&type=Timeline" />
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=sanidhyy/space-portfolio&type=Timeline" />
 </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken, so the project's popularity is no longer visible. This PR updates the chart to use a working alternative that keeps the chart rendering correctly for visitors.

The wrapping link now uses a hash-based URL and the chart images point to the new endpoint.