### PR TITLE
Migrate vscode settings.json to js/ts.tsdk keys

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "files.associations": {
+    "*.css": "tailwindcss"
+  },
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true
 }


### PR DESCRIPTION
## Summary
- Update workspace editor settings to the unified `js/ts.tsdk.path` / `js/ts.tsdk.promptToUseWorkspaceVersion` keys (and Tailwind CSS file association where the project uses Tailwind).
- Un-ignore `.vscode/settings.json` when it was gitignored so workspace editor settings are shared.

Related: https://linear.app/sanidhyy/issue/SAN-121/migrate-vscode-settingsjson

## Test plan
- [ ] Open the repo in the editor and confirm workspace TypeScript is offered (TypeScript repos)
- [ ] For Tailwind repos, confirm `*.css` is associated with Tailwind CSS